### PR TITLE
Bug Hotfix

### DIFF
--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -66,7 +66,7 @@ func handleMsgCreateBond(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgCre
 		return types.ErrBondTokenCannotBeStakingToken(DefaultCodeSpace).Result()
 	}
 
-	reserveAddress := sdk.AccAddress([]byte(keeper.GetNumberOfBonds(ctx).String()))
+	reserveAddress := keeper.GetNextUnusedReserveAddress(ctx)
 
 	bond := NewBond(msg.Token, msg.Name, msg.Description, msg.Creator,
 		msg.FunctionType, msg.FunctionParameters, msg.ReserveTokens,

--- a/x/bonds/handler.go
+++ b/x/bonds/handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ixofoundation/ixo-cosmos/x/bonds/internal/keeper"
 	"github.com/ixofoundation/ixo-cosmos/x/bonds/internal/types"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/crypto/ed25519"
 	"strings"
 )
 
@@ -67,7 +66,7 @@ func handleMsgCreateBond(ctx sdk.Context, keeper keeper.Keeper, msg types.MsgCre
 		return types.ErrBondTokenCannotBeStakingToken(DefaultCodeSpace).Result()
 	}
 
-	reserveAddress := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	reserveAddress := sdk.AccAddress([]byte(keeper.GetNumberOfBonds(ctx).String()))
 
 	bond := NewBond(msg.Token, msg.Name, msg.Description, msg.Creator,
 		msg.FunctionType, msg.FunctionParameters, msg.ReserveTokens,

--- a/x/bonds/internal/keeper/bonds.go
+++ b/x/bonds/internal/keeper/bonds.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ixofoundation/ixo-cosmos/x/bonds/internal/types"
@@ -13,7 +14,7 @@ func (k Keeper) GetBondIterator(ctx sdk.Context) sdk.Iterator {
 }
 
 func (k Keeper) GetNumberOfBonds(ctx sdk.Context) sdk.Int {
-	var count sdk.Int
+	count := sdk.ZeroInt()
 	iterator := k.GetBondIterator(ctx)
 	for ; iterator.Valid(); iterator.Next() {
 		var bond types.Bond
@@ -21,6 +22,26 @@ func (k Keeper) GetNumberOfBonds(ctx sdk.Context) sdk.Int {
 		count = count.AddRaw(1)
 	}
 	return count
+}
+
+func (k Keeper) GetNextUnusedReserveAddress(ctx sdk.Context) sdk.AccAddress {
+	var buffer bytes.Buffer
+
+	// Get number of bonds prefixed with a letter (in this case, A)
+	numString := "A" + k.GetNumberOfBonds(ctx).String()
+
+	// Append numString to a base HEX address
+	buffer.WriteString("A97B2E13A94AF4A1D3EC729DC422C6341BAEEDC9")
+	buffer.WriteString(numString)
+
+	// Truncate from the front to the required length (38) and parse to address
+	truncated := buffer.String()[len(buffer.String())-40:]
+	res, err := sdk.AccAddressFromHex(truncated)
+	if err != nil {
+		panic(err)
+	}
+
+	return res
 }
 
 func (k Keeper) GetBond(ctx sdk.Context, bondDid ixo.Did) (bond types.Bond, found bool) {

--- a/x/bonds/internal/keeper/bonds.go
+++ b/x/bonds/internal/keeper/bonds.go
@@ -12,6 +12,17 @@ func (k Keeper) GetBondIterator(ctx sdk.Context) sdk.Iterator {
 	return sdk.KVStorePrefixIterator(store, types.BondsKeyPrefix)
 }
 
+func (k Keeper) GetNumberOfBonds(ctx sdk.Context) sdk.Int {
+	var count sdk.Int
+	iterator := k.GetBondIterator(ctx)
+	for ; iterator.Valid(); iterator.Next() {
+		var bond types.Bond
+		k.cdc.MustUnmarshalBinaryBare(iterator.Value(), &bond)
+		count = count.AddRaw(1)
+	}
+	return count
+}
+
 func (k Keeper) GetBond(ctx sdk.Context, bondDid ixo.Did) (bond types.Bond, found bool) {
 	store := ctx.KVStore(k.storeKey)
 	if !k.BondExists(ctx, bondDid) {


### PR DESCRIPTION
This MR solves the issue that on-the-fly random address generation was being used for reserve addresses. This works with no problems in a single-node environment but in a network of nodes, each node will generate a random address, thus breaking the determinism of the chain. 